### PR TITLE
カウンターアプリをVuexで実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tsconfig-paths": "^3.8.0",
     "typescript": "^3.3.3",
     "typescript-eslint-parser": "^22.0.0",
-    "vue-jest": "^3.0.3"
+    "vue-jest": "^3.0.3",
+    "vuex-class": "^0.3.1"
   }
 }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -32,3 +32,9 @@
     </footer>
   </div>
 </template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+@Component
+export default class DefaultLayout extends Vue {}
+</script>

--- a/src/pages/counter.vue
+++ b/src/pages/counter.vue
@@ -1,16 +1,44 @@
 <template>
   <div class="container">
     <div class="result">
-      🐱が○○匹いる。
+      {{ prefixMessage() }}
+      {{ currentCounter.counter }}
+      {{ suffixMessage() }}
     </div>
-    <button class="button is-info increment">
+    <button class="button is-info increment" @click="increment">
       increment
     </button>
-    <button class="button is-danger decrement">
+    <button class="button is-danger decrement" @click="decrement">
       decrement
     </button>
   </div>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  computed: {
+    currentCounter() {
+      return this.$store.getters['counter/currentCounter']();
+    }
+  },
+  methods: {
+    prefixMessage() {
+      return '🐱が';
+    },
+    suffixMessage() {
+      return '匹いる。';
+    },
+    increment() {
+      this.$store.dispatch('counter/increment');
+    },
+    decrement() {
+      this.$store.dispatch('counter/decrement');
+    }
+  }
+});
+</script>
 
 <style scoped>
 .container {

--- a/src/store/counter.ts
+++ b/src/store/counter.ts
@@ -1,0 +1,43 @@
+import { ActionTree, MutationTree, GetterTree, ActionContext } from 'vuex';
+
+export interface State {
+  counter: number;
+}
+
+export const types = {
+  INCREMENT: 'INCREMENT',
+  DECREMENT: 'DECREMENT'
+};
+
+export const state = (): State => ({
+  counter: 0
+});
+
+export const getters: GetterTree<State, {}> = {
+  currentCounter: state => () => {
+    return { counter: state.counter };
+  }
+};
+
+export interface Actions<S, R> extends ActionTree<S, R> {
+  increment(context: ActionContext<S, R>): void;
+  decrement(context: ActionContext<S, R>): void;
+}
+
+export const actions: Actions<State, {}> = {
+  increment: ({ commit }) => {
+    commit(types.INCREMENT);
+  },
+  decrement: ({ commit }) => {
+    commit(types.DECREMENT);
+  }
+};
+
+export const mutations: MutationTree<State> = {
+  [types.INCREMENT]: (state): void => {
+    state.counter++;
+  },
+  [types.DECREMENT]: (state): void => {
+    state.counter--;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9195,6 +9195,11 @@ vue@^2.5.22:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.7.tgz#254f188e7621d2d19ee28d0c0442c6d21b53ae2d"
   integrity sha512-g7ADfQ82QU+j6F/bVDioVQf2ccIMYLuR4E8ev+RsDBlmwRkhGO3HhgF4PF9vpwjdPpxyb1zzLur2nQ2oIMAMEg==
 
+vuex-class@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/vuex-class/-/vuex-class-0.3.1.tgz#3c0b946bcff4cf2be1904de5b0cab1a3dd5c41d5"
+  integrity sha512-d7Hc+ItQx6p9E/2mEWiyrvyEuo7Uj0mq4VNImd7dmxTelnkhOavKPMEG1Xdypug2RlPEYv0920IOa3hdVZ+4AA==
+
 vuex@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.0.tgz#634b81515cf0cfe976bd1ffe9601755e51f843b9"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/nuxt-boilerplate/issues/10

# 関連URL
http://127.0.0.1:3000/counter

# Doneの定義
- Vuexを使ったカウンターアプリが実装されている事

# スクリーンショット
<img width="519" alt="2019-03-04 2 41 41" src="https://user-images.githubusercontent.com/11032365/53699009-12b4db80-3e27-11e9-9829-f3f7669f041a.png">

# 変更点概要

## 技術的変更点概要
vuexのmoduleモードを使ってカウンターアプリを実装。

# 補足情報
一応動いているが、全くタイプセーフではなく実用に耐える物ではないので、次回以降のPRで改善していく。やはりクラスベースの書き方じゃないとタイプセーフは厳しいかも。