### PR TITLE
Qiitaの認可サーバーにリダイレクトする処理を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ dist
 # IDE
 .idea
 nuxt-boilerplate.iml
+
+# env File
+.env
+.envrc

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@nuxtjs/bulma": "^1.2.2",
     "cross-env": "^5.2.0",
     "express": "^4.16.3",
-    "nuxt": "^2.4.3"
+    "nuxt": "^2.4.3",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@types/eslint": "^4.16.6",
@@ -29,6 +30,7 @@
     "@types/jest": "^24.0.6",
     "@types/node": "^10.12.27",
     "@types/prettier": "1.16.1",
+    "@types/uuid": "^3.4.4",
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/bulma": "^1.2.2",
+    "cookie-parser": "^1.4.4",
     "cross-env": "^5.2.0",
     "express": "^4.16.3",
     "nuxt": "^2.4.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.1",
     "@types/eslint": "^4.16.6",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/express": "^4.16.1",

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -9,6 +9,7 @@
       <div class="navbar-end">
         <div class="navbar-item">
           <div class="buttons">
+            <a class="button is-light" href="/oauth/request">Qiitaでログイン</a>
             <a class="button is-light">
               <nuxt-link to="/counter">Counter</nuxt-link>
             </a>

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,7 +1,9 @@
 import express, { Router } from 'express';
+import cookieParser from 'cookie-parser';
 import consola from 'consola';
 import weather from './api/weather';
 import animals from './api/animals';
+import oauth from './auth/oauth';
 const router = Router();
 const { Nuxt, Builder } = require('nuxt');
 const host: string = process.env.HOST || '127.0.0.1';
@@ -9,6 +11,7 @@ const port: number = Number(process.env.PORT) || 3000;
 
 router.use(weather);
 router.use(animals);
+router.use(oauth);
 
 export default async function() {
   const app = express();
@@ -27,7 +30,9 @@ export default async function() {
     await builder.build();
   }
 
+  app.use(cookieParser());
   app.use('/api', router);
+  app.use('/oauth', router);
   // Give nuxt middleware to express
   app.use(nuxt.render);
 

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,20 @@
+import uuid from 'uuid';
+import url from 'url';
+import { clientId } from './constants/qiita';
+
+export const createAuthorizationState = (): string => {
+  return uuid.v4();
+};
+
+export const createAuthorizationUrl = (authorizationState: string): string => {
+  return url.format({
+    protocol: 'https',
+    host: 'qiita.com',
+    pathname: '/api/v2/oauth/authorize',
+    query: {
+      client_id: clientId(),
+      scope: 'read_qiita',
+      state: authorizationState
+    }
+  });
+};

--- a/src/server/auth/oauth.ts
+++ b/src/server/auth/oauth.ts
@@ -1,0 +1,33 @@
+import { Router, Request, Response } from 'express';
+import { createAuthorizationState, createAuthorizationUrl } from '../auth';
+
+const router = Router();
+
+router.get('/request', (req: Request, res: Response) => {
+  const authorizationState = createAuthorizationState();
+  res.cookie('authorizationState', authorizationState, {
+    path: '/',
+    httpOnly: true
+  });
+
+  return res.redirect(302, createAuthorizationUrl(authorizationState));
+});
+
+router.get('/callback', async (req: Request, res: Response) => {
+  if (req.cookies.authorizationState == null) {
+    // TODO 何らかのエラー処理を行う
+  }
+
+  if (req.cookies.authorizationState !== req.query.state) {
+    // TODO stateが一致しない場合は何らかのエラー処理を行う
+  }
+
+  if (req.query.code == null) {
+    // TODO 認可コードが含まれない場合は何らかのエラー処理を行う
+  }
+
+  // TODO 仮実装なので後でトークン発行処理に置き換える
+  return res.status(200).json({ code: req.query.code });
+});
+
+export default router;

--- a/src/server/constants/qiita.ts
+++ b/src/server/constants/qiita.ts
@@ -1,0 +1,11 @@
+export const clientId = (): string => {
+  return typeof process.env.QIITA_CLIENT_ID === 'string'
+    ? process.env.QIITA_CLIENT_ID
+    : '';
+};
+
+export const clientSecret = (): string => {
+  return typeof process.env.QIITA_CLIENT_SECRET === 'string'
+    ? process.env.QIITA_CLIENT_SECRET
+    : '';
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie-parser@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie-parser/-/cookie-parser-1.4.1.tgz#e88a39c41960f31549b4c52dd8620aa4a2feb4bb"
+  integrity sha512-iJY6B3ZGufLiDf2OCAgiAAQuj1sMKC/wz/7XCEjZ+/MDuultfFJuSwrBKcLSmJ5iYApLzCCYBYJZs0Ws8GPmwA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/eslint-plugin-prettier@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-plugin-prettier/-/eslint-plugin-prettier-2.2.0.tgz#26170ee65ce05d811f3ef6fc2987acd525066c7f"
@@ -1145,7 +1152,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.16.1":
+"@types/express@*", "@types/express@^4.16.1":
   version "4.16.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
   integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
@@ -2738,6 +2745,14 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-parser@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.4.tgz#e6363de4ea98c3def9697b93421c09f30cf5d188"
+  integrity sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
 
 cookie-signature@1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,13 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.9.tgz#693e76a52f61a2f1e7fb48c0eef167b95ea4ffd0"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/nuxt-boilerplate/issues/19

# 関連URL
- http://127.0.0.1:3000/oauth/request
- http://127.0.0.1:3000/oauth/callback

# Doneの定義
- 認可サーバーから認可コードが取得出来ている事

# スクリーンショット
<img width="257" alt="QiitaLogin" src="https://user-images.githubusercontent.com/11032365/55562337-afbcaa00-572e-11e9-8705-b06602dbc26a.png">

# 変更点概要

## 技術的変更点概要
Qiitaへ認可リクエストを送り認可コードを取得するところまで実装。
