### PR TITLE
Vue.extendを使い型解決が行われるように改修

### DIFF
--- a/src/components/Cat.vue
+++ b/src/components/Cat.vue
@@ -5,21 +5,15 @@
 </template>
 
 <script lang="ts">
-import Vue, { ComponentOptions } from 'vue';
+import Vue from 'vue';
 
-interface ICat extends Vue {
-  message: string;
-}
-
-export { ICat as interface };
-
-export default {
+export default Vue.extend({
   data() {
     return {
       message: '🐱'
     };
   }
-} as ComponentOptions<ICat>;
+});
 </script>
 
 <style scoped>

--- a/src/components/CounterButton.vue
+++ b/src/components/CounterButton.vue
@@ -10,14 +10,15 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import { mapActions } from 'vuex';
 
-export default {
+export default Vue.extend({
   name: 'CounterButton',
   methods: {
     ...mapActions('counter', ['increment', 'decrement'])
   }
-};
+});
 </script>
 
 <style scoped>

--- a/src/components/CurrentCount.vue
+++ b/src/components/CurrentCount.vue
@@ -7,9 +7,10 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-export default {
+export default Vue.extend({
   name: 'CurrentCount',
   computed: {
     ...mapGetters('counter', ['currentCounter'])
@@ -22,7 +23,7 @@ export default {
       return '匹いる。';
     }
   }
-};
+});
 </script>
 
 <style scoped>

--- a/src/components/Dog.vue
+++ b/src/components/Dog.vue
@@ -5,21 +5,15 @@
 </template>
 
 <script lang="ts">
-import Vue, { ComponentOptions } from 'vue';
+import Vue from 'vue';
 
-interface IDog extends Vue {
-  message: string;
-}
-
-export { IDog as interface };
-
-export default {
+export default Vue.extend({
   data() {
     return {
       message: '🐶'
     };
   }
-} as ComponentOptions<IDog>;
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/nuxt-boilerplate/issues/26

# Doneの定義
- Component内で型解決が出来るようになっている事

## 技術的変更点概要
[こちら](https://qiita.com/potato4d/items/c9c0c8e674f20c85948a) を参考にVue.extendを使った形に変更。

# 補足情報
vue-class-componentなどの利用も考えたが少し特殊な書き方になるので、ポピュラーな書き方が出来るVue.extendを使った形に統一しました。
